### PR TITLE
fix: standardize editor configuration across tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+max_line_length = 80
+trim_trailing_whitespace = false

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: mislam

--- a/.prettierrc
+++ b/.prettierrc
@@ -11,7 +11,8 @@
 			"options": {
 				"printWidth": 80,
 				"tabWidth": 2,
-				"useTabs": false
+				"useTabs": false,
+				"proseWrap": "preserve"
 			}
 		}
 	]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-	"recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+	"recommendations": [
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+		"editorconfig.editorconfig"
+	]
 }

--- a/README.md
+++ b/README.md
@@ -125,10 +125,19 @@ my-app/
 
 ## Editor Setup
 
-Install
-[VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+When opening the project in VS Code, you'll be prompted to install recommended
+extensions. These include:
+
+[ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint),
+[Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode),
 and
-[Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode).
+[EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).
+
+This project includes configuration files that will automatically:
+
+- Apply consistent code formatting
+- Enforce code quality rules
+- Configure editor settings (line endings, indentation)
 
 ## License
 


### PR DESCRIPTION
- Enhance .editorconfig with markdown-specific rules
- Add EditorConfig extension to VS Code recommendations
- Align Prettier's markdown handling with EditorConfig
- Document editor setup process in README

Closes #4